### PR TITLE
chore(ci): Makefile - updates and targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ make quickstart TLS=1 PROMETHEUS=1
 ### To Uninstall
 
 ```sh
-minikube delete -p north
+make minikube-delete
 ```
 
 


### PR DESCRIPTION
  - update k8s to 1.31.2
  - cilium to 1.16.3
  - fix quickstart
  - split out quickstart into separate targets
  - move quickstart help into its own help section
  - add minikube delete
