### PR TITLE
fix PID and process leak

### DIFF
--- a/Dockerfile.valkey
+++ b/Dockerfile.valkey
@@ -23,6 +23,7 @@ FROM alpine:3.21.3 AS valkey
 RUN apk add --no-cache \
 	openssl=3.3.3-r0 \
 	ca-certificates=20241121-r1 \
+	coreutils=9.5-r2 \
 	&& addgroup -S valkey -g 1009 \
 	&& adduser -S -G valkey valkey -u 1009 \
 	&& mkdir /etc/valkey \

--- a/internal/controller/scripts/ping_liveness_local.sh
+++ b/internal/controller/scripts/ping_liveness_local.sh
@@ -2,7 +2,7 @@
 set -e
 if [ ! -z "$VALKEY_PASSWORD" ]; then export REDISCLI_AUTH=$VALKEY_PASSWORD; fi;
 response=$(
-  timeout -s 15 $1 \
+  timeout --foreground -s 15 $1 \
   valkey-cli \
     -h localhost \
     -p $VALKEY_PORT_NUMBER \

--- a/internal/controller/scripts/ping_liveness_local_tls.sh
+++ b/internal/controller/scripts/ping_liveness_local_tls.sh
@@ -4,7 +4,7 @@ set -e
 if [ ! -z "$VALKEY_PASSWORD" ]; then export REDISCLI_AUTH=$VALKEY_PASSWORD; fi;
 
 	response=$(
-	timeout -s 15 $1 \
+	timeout --foreground -s 15 $1 \
 	valkey-cli \
 		-h localhost \
 		-p $VALKEY_TLS_PORT_NUMBER \

--- a/internal/controller/scripts/ping_readiness_local.sh
+++ b/internal/controller/scripts/ping_readiness_local.sh
@@ -4,7 +4,7 @@ set -e
 VALKEY_STATUS_FILE=/tmp/.valkey_cluster_check
 if [ ! -z "$VALKEY_PASSWORD" ]; then export REDISCLI_AUTH=$VALKEY_PASSWORD; fi;
 response=$(
-  timeout -s 15 $1 \
+  timeout --foreground -s 15 $1 \
   valkey-cli \
     -h localhost \
     -p $VALKEY_PORT_NUMBER \
@@ -21,7 +21,7 @@ fi
 nodes=$(echo $VALKEY_NODES | wc -w)
 if [ ! -f "$VALKEY_STATUS_FILE" ] && [ "$nodes" != "1" ]; then
   response=$(
-    timeout -s 15 $1 \
+    timeout --foreground -s 15 $1 \
     valkey-cli \
       -h localhost \
       -p $VALKEY_PORT_NUMBER \

--- a/internal/controller/scripts/ping_readiness_local_tls.sh
+++ b/internal/controller/scripts/ping_readiness_local_tls.sh
@@ -5,7 +5,7 @@ VALKEY_STATUS_FILE=/tmp/.valkey_cluster_check
 if [ ! -z "$VALKEY_PASSWORD" ]; then export REDISCLI_AUTH=$VALKEY_PASSWORD; fi;
 
 	response=$(
-	timeout -s 15 $1 \
+	timeout --foreground -s 15 $1 \
 	valkey-cli \
 		-h localhost \
 		-p $VALKEY_TLS_PORT_NUMBER \
@@ -28,7 +28,7 @@ fi
 count=$(echo $VALKEY_NODES | wc -w)
 if [ ! -f "$VALKEY_STATUS_FILE" ] && [ "$count" != "1" ]; then
 	response=$(
-		timeout -s 15 $1 \
+		timeout --foreground -s 15 $1 \
 		valkey-cli \
 			-h localhost \
 			-p $VALKEY_TLS_PORT_NUMBER \


### PR DESCRIPTION
So I noticed memory usage increasing in our environment and started to wonder what could be happening.

![Screenshot 2025-02-20 at 10-59-39 Valkey Cluster Metrics - Software Platform Team - Dashboards - Grafana](https://github.com/user-attachments/assets/498498fb-0944-4f17-a8d7-0710034d82f9)
 
Using kubectl exec and running `ps` in the pod I saw that there was a large number of timeout processes lying around. Based on this comment (https://github.com/bitnami/charts/issues/10002#issuecomment-2482110450) I decided to install gnu coreutils and add the foreground flag, and after testing that in our environment I can confirm it's working well.