### PR TITLE
allow the exporter side-car to deploy in absence of a prometheus operator

### DIFF
--- a/api/v1/valkey_types.go
+++ b/api/v1/valkey_types.go
@@ -67,6 +67,10 @@ type ValkeySpec struct {
 	// +optional
 	PrometheusLabels map[string]string `json:"prometheusLabels,omitempty"`
 
+	// Use a service monitor
+	// +kubebuilder:default:=true
+	PrometheusOperator bool `json:"prometheusOperator,omitempty"`
+
 	// Cluster Domain - used for DNS
 	// +kubebuilder:default:=cluster.local
 	ClusterDomain string `json:"clusterDomain"`

--- a/config/crd/bases/hyperspike.io_valkeys.yaml
+++ b/config/crd/bases/hyperspike.io_valkeys.yaml
@@ -244,6 +244,10 @@ spec:
                   type: string
                 description: Extra prometheus labels for operator targeting
                 type: object
+              prometheusOperator:
+                default: true
+                description: Use a service monitor
+                type: boolean
               replicas:
                 default: 0
                 description: Number of replicas

--- a/internal/controller/valkey_controller.go
+++ b/internal/controller/valkey_controller.go
@@ -141,7 +141,7 @@ func (r *ValkeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if err := r.upsertServiceAccount(ctx, valkey); err != nil {
 		return ctrl.Result{}, err
 	}
-	if valkey.Spec.Prometheus {
+	if valkey.Spec.Prometheus && valkey.Spec.PrometheusOperator {
 		if err := r.upsertServiceMonitor(ctx, valkey); err != nil {
 			return ctrl.Result{}, err
 		}


### PR DESCRIPTION
When a prometheus operator is not available, monitoring should be available via normal pod annotations. It would be the user responsibility to set those up. This change should not affect the previous behavior; it only excludes the service & service monitor when the added key is explicitly set to false. 

Should address https://github.com/hyperspike/valkey-operator/issues/261