### PR TITLE
feat: decouple prometheus exporter and servicemonitor

### DIFF
--- a/api/v1/valkey_types.go
+++ b/api/v1/valkey_types.go
@@ -67,6 +67,10 @@ type ValkeySpec struct {
 	// +optional
 	PrometheusLabels map[string]string `json:"prometheusLabels,omitempty"`
 
+	// ServiceMonitor Enabled
+	// +kubebuilder:default:=false
+	ServiceMonitor bool `json:"serviceMonitor"`
+
 	// Cluster Domain - used for DNS
 	// +kubebuilder:default:=cluster.local
 	ClusterDomain string `json:"clusterDomain"`

--- a/config/crd/bases/hyperspike.io_valkeys.yaml
+++ b/config/crd/bases/hyperspike.io_valkeys.yaml
@@ -309,6 +309,10 @@ spec:
                       More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                 type: object
+              serviceMonitor:
+                default: false
+                description: ServiceMonitor Enabled
+                type: boolean
               servicePassword:
                 description: Service Password
                 properties:
@@ -785,6 +789,7 @@ spec:
             - anonymousAuth
             - clusterDomain
             - prometheus
+            - serviceMonitor
             - volumePermissions
             type: object
           status:


### PR DESCRIPTION
note: if ServiceMonitor is enabled then the Prometheus switch is effectively enabled as well.

Supersedes #283 
