### PR TITLE
fix: prevent nil map panic and applyset label/annotation propagation

### DIFF
--- a/internal/controller/valkey_controller.go
+++ b/internal/controller/valkey_controller.go
@@ -25,7 +25,6 @@ import (
 	"embed"
 	"fmt"
 	"io"
-	"maps"
 	"math/big"
 	"net"
 	"os"
@@ -262,15 +261,40 @@ func (r *ValkeyReconciler) validateValkeySpec(valkey *hyperv1.Valkey) error {
 }
 
 func labels(valkey *hyperv1.Valkey) map[string]string {
-	l := maps.Clone(valkey.Labels)
+	l := make(map[string]string)
+	for k, v := range valkey.Labels {
+		// Skip applyset ownership labels — these are injected by tools like
+		// KRO, ArgoCD, or kubectl apply --prune. Propagating them to child
+		// resources (Services, StatefulSets) causes the tool to treat those
+		// children as managed, leading to unintended pruning.
+		if strings.HasPrefix(k, "applyset.kubernetes.io/") {
+			continue
+		}
+		l[k] = v
+	}
 	l["app.kubernetes.io/name"] = Valkey
 	l["app.kubernetes.io/instance"] = valkey.Name
 	l["app.kubernetes.io/component"] = Valkey
 	return l
 }
 
+// annotations returns the Valkey CR's annotations, filtering out
+// applyset.kubernetes.io/* entries for the same reason as labels().
 func annotations(valkey *hyperv1.Valkey) map[string]string {
-	return valkey.Annotations
+	if len(valkey.Annotations) == 0 {
+		return nil
+	}
+	a := make(map[string]string, len(valkey.Annotations))
+	for k, v := range valkey.Annotations {
+		if strings.HasPrefix(k, "applyset.kubernetes.io/") {
+			continue
+		}
+		a[k] = v
+	}
+	if len(a) == 0 {
+		return nil
+	}
+	return a
 }
 
 func (r *ValkeyReconciler) getCACertificate(ctx context.Context, valkey *hyperv1.Valkey) (string, error) {

--- a/internal/controller/valkey_controller_utils_test.go
+++ b/internal/controller/valkey_controller_utils_test.go
@@ -55,6 +55,126 @@ func TestLabels(t *testing.T) {
 	}
 }
 
+func TestLabelsNilMap(t *testing.T) {
+	valkey := &hyperspikeiov1.Valkey{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-resource",
+			Namespace: "default",
+			// Labels intentionally nil
+		},
+	}
+	result := labels(valkey)
+	if result == nil {
+		t.Fatal("Expected non-nil map, got nil")
+	}
+	if result["app.kubernetes.io/name"] != "valkey" {
+		t.Errorf("Expected %v, got %v", "valkey", result["app.kubernetes.io/name"])
+	}
+	if result["app.kubernetes.io/instance"] != "test-resource" {
+		t.Errorf("Expected %v, got %v", "test-resource", result["app.kubernetes.io/instance"])
+	}
+}
+
+func TestLabelsApplySetFiltering(t *testing.T) {
+	valkey := &hyperspikeiov1.Valkey{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-resource",
+			Namespace: "default",
+			Labels: map[string]string{
+				"app":                            "valkey",
+				"team":                           "platform",
+				"applyset.kubernetes.io/part-of":  "applyset-abc123",
+				"applyset.kubernetes.io/id":       "some-id",
+				"applyset.kubernetes.io/tooling":  "kro/v0.8.5",
+			},
+		},
+	}
+	result := labels(valkey)
+
+	// User labels should be propagated
+	if result["app"] != "valkey" {
+		t.Errorf("Expected user label 'app' to be propagated, got %v", result["app"])
+	}
+	if result["team"] != "platform" {
+		t.Errorf("Expected user label 'team' to be propagated, got %v", result["team"])
+	}
+
+	// ApplySet labels should NOT be propagated
+	if _, ok := result["applyset.kubernetes.io/part-of"]; ok {
+		t.Error("applyset.kubernetes.io/part-of should not be propagated to child resources")
+	}
+	if _, ok := result["applyset.kubernetes.io/id"]; ok {
+		t.Error("applyset.kubernetes.io/id should not be propagated to child resources")
+	}
+	if _, ok := result["applyset.kubernetes.io/tooling"]; ok {
+		t.Error("applyset.kubernetes.io/tooling should not be propagated to child resources")
+	}
+
+	// Standard labels should still be set
+	if result["app.kubernetes.io/name"] != "valkey" {
+		t.Errorf("Expected %v, got %v", "valkey", result["app.kubernetes.io/name"])
+	}
+}
+
+func TestAnnotationsApplySetFiltering(t *testing.T) {
+	valkey := &hyperspikeiov1.Valkey{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-resource",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"user-annotation":                             "keep-me",
+				"applyset.kubernetes.io/contains-group-kinds": "Service,Deployment.apps",
+				"applyset.kubernetes.io/additional-namespaces": "flux-system",
+				"applyset.kubernetes.io/tooling":               "kro/v0.8.5",
+			},
+		},
+	}
+	result := annotations(valkey)
+
+	// User annotations should be propagated
+	if result["user-annotation"] != "keep-me" {
+		t.Errorf("Expected user annotation to be propagated, got %v", result["user-annotation"])
+	}
+
+	// ApplySet annotations should NOT be propagated
+	if _, ok := result["applyset.kubernetes.io/contains-group-kinds"]; ok {
+		t.Error("applyset.kubernetes.io/contains-group-kinds should not be propagated to child resources")
+	}
+	if _, ok := result["applyset.kubernetes.io/additional-namespaces"]; ok {
+		t.Error("applyset.kubernetes.io/additional-namespaces should not be propagated to child resources")
+	}
+}
+
+func TestAnnotationsOnlyApplySet(t *testing.T) {
+	valkey := &hyperspikeiov1.Valkey{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-resource",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"applyset.kubernetes.io/contains-group-kinds": "Service",
+				"applyset.kubernetes.io/tooling":               "kro/v0.8.5",
+			},
+		},
+	}
+	result := annotations(valkey)
+	if result != nil {
+		t.Errorf("Expected nil when all annotations are filtered, got %v", result)
+	}
+}
+
+func TestAnnotationsNil(t *testing.T) {
+	valkey := &hyperspikeiov1.Valkey{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-resource",
+			Namespace: "default",
+		},
+	}
+	result := annotations(valkey)
+	if result != nil {
+		t.Errorf("Expected nil for empty annotations, got %v", result)
+	}
+}
+
 func TestAnnotations(t *testing.T) {
 	testAnnotations := map[string]string{
 		"app": "valkey",


### PR DESCRIPTION
The labels() function used maps.Clone(valkey.Labels) which returns nil when the input is nil, causing a panic on the next map assignment. While validateValkeySpec() guards against nil labels during normal reconciliation, the labels() function should be self-contained.

Additionally, when tools like KRO, ArgoCD, or kubectl apply --prune inject applyset.kubernetes.io/* labels and annotations onto the Valkey CR, the operator propagated them to child Services and StatefulSets. This causes the tools to treat those children as managed resources, leading to unintended pruning: the tool deletes the Service, the operator recreates it, and the cycle repeats.

Changes:
- labels(): initialize with make() instead of maps.Clone(), filter applyset.kubernetes.io/* labels before propagating to children
- annotations(): copy and filter instead of returning the raw map reference, filter applyset.kubernetes.io/* annotations
- Added tests for nil labels, applyset label filtering, applyset annotation filtering, and nil annotations