### PR TITLE
fix: Respect ClusterPreferredEndpointType and set ClusterAnnounceHostname

### DIFF
--- a/internal/controller/valkey_controller.go
+++ b/internal/controller/valkey_controller.go
@@ -232,6 +232,11 @@ func (r *ValkeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5}, nil
 		}
 	}
+	if valkey.Spec.ClusterPreferredEndpointType == "hostname" {
+		if err := r.setClusterAnnounceHostname(ctx, valkey); err != nil {
+			return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5}, nil
+		}
+	}
 
 	return ctrl.Result{}, nil
 }
@@ -259,6 +264,18 @@ func (r *ValkeyReconciler) validateValkeySpec(valkey *hyperv1.Valkey) error {
 		valkey.Labels = map[string]string{}
 	}
 	return nil
+}
+
+// resolveEndpointType returns the effective cluster endpoint type for a Valkey CR.
+// TLS always implies hostname. When not set, ip is the default.
+func resolveEndpointType(valkey *hyperv1.Valkey) string {
+	if valkey.Spec.TLS {
+		return "hostname"
+	}
+	if valkey.Spec.ClusterPreferredEndpointType != "" {
+		return valkey.Spec.ClusterPreferredEndpointType
+	}
+	return "ip"
 }
 
 func labels(valkey *hyperv1.Valkey) map[string]string {
@@ -869,6 +886,55 @@ func (r *ValkeyReconciler) setClusterAnnounceIp(ctx context.Context, valkey *hyp
 	}
 	*/
 	return nil
+}
+
+// setClusterAnnounceHostname sets cluster-announce-hostname on every pod so that
+// the cluster topology is stable across pod restarts when ClusterPreferredEndpointType
+// is "hostname". Without this, nodes.conf retains the old pod IP after rescheduling
+// and clients that re-read cluster slots receive a stale address.
+func (r *ValkeyReconciler) setClusterAnnounceHostname(ctx context.Context, valkey *hyperv1.Valkey) error {
+	logger := log.FromContext(ctx)
+
+	logger.Info("setting cluster announce hostname")
+
+	pods := &corev1.PodList{}
+	if err := r.List(ctx, pods, client.InNamespace(valkey.Namespace), client.MatchingLabels(labels(valkey))); err != nil {
+		logger.Error(err, "failed to list pods")
+		return err
+	}
+
+	var err error
+	for _, pod := range pods.Items {
+		hostname := fmt.Sprintf("%s.%s-headless.%s.svc.%s", pod.Name, valkey.Name, valkey.Namespace, valkey.Spec.ClusterDomain)
+		address := fmt.Sprintf("%s:%d", hostname, ValkeyPort)
+		c, clientErr := r.getClient(ctx, valkey, address, true)
+		if clientErr != nil {
+			logger.Error(clientErr, "failed to create valkey client", "pod", pod.Name)
+			return clientErr
+		}
+		defer c.Close()
+
+		logger.Info("setting cluster announce hostname", "hostname", hostname, "pod", pod.Name)
+		r.Recorder.Event(valkey, "Normal", "Setting",
+			fmt.Sprintf("Setting cluster announce hostname %s on pod %s for %s/%s", hostname, pod.Name, valkey.Namespace, valkey.Name))
+
+		out, err := c.Do(ctx, c.B().ConfigSet().ParameterValue().ParameterValue("cluster-announce-hostname", hostname).Build()).ToString()
+		if err != nil {
+			logger.Error(err, "failed to set cluster announce hostname "+out, "pod", pod.Name)
+			return err
+		}
+		cfgs, err := c.Do(ctx, c.B().ConfigGet().Parameter("cluster-announce-hostname").Build()).ToMap()
+		if err != nil {
+			logger.Error(err, "failed to get cluster announce hostname", "pod", pod.Name)
+		}
+		for k, v := range cfgs {
+			str, _ := v.ToString()
+			if str != hostname {
+				logger.Error(err, "failed to verify cluster announce hostname", k, str)
+			}
+		}
+	}
+	return err
 }
 
 func (r *ValkeyReconciler) fetchExternalIPs(ctx context.Context, valkey *hyperv1.Valkey) (map[string]string, error) {
@@ -2307,10 +2373,9 @@ func (r *ValkeyReconciler) upsertStatefulSet(ctx context.Context, valkey *hyperv
 
 	logger.Info("upserting statefulset")
 	tls := "no"
-	endpointType := "ip"
+	endpointType := resolveEndpointType(valkey)
 	if valkey.Spec.TLS {
 		tls = "yes"
-		endpointType = "hostname"
 	}
 	image := r.GlobalConfig.ValkeyImage
 	if valkey.Spec.Image != "" {

--- a/internal/controller/valkey_controller_utils_test.go
+++ b/internal/controller/valkey_controller_utils_test.go
@@ -92,6 +92,52 @@ func TestServicePasswordKey(t *testing.T) {
 	}
 }
 
+func TestResolveEndpointType(t *testing.T) {
+	tests := []struct {
+		name     string
+		spec     hyperspikeiov1.ValkeySpec
+		expected string
+	}{
+		{
+			name:     "defaults to ip when nothing is set",
+			spec:     hyperspikeiov1.ValkeySpec{},
+			expected: "ip",
+		},
+		{
+			name:     "respects ClusterPreferredEndpointType=hostname",
+			spec:     hyperspikeiov1.ValkeySpec{ClusterPreferredEndpointType: "hostname"},
+			expected: "hostname",
+		},
+		{
+			name:     "respects ClusterPreferredEndpointType=ip explicitly",
+			spec:     hyperspikeiov1.ValkeySpec{ClusterPreferredEndpointType: "ip"},
+			expected: "ip",
+		},
+		{
+			name:     "TLS overrides ClusterPreferredEndpointType to hostname",
+			spec:     hyperspikeiov1.ValkeySpec{TLS: true, ClusterPreferredEndpointType: "ip"},
+			expected: "hostname",
+		},
+		{
+			name:     "TLS implies hostname even when ClusterPreferredEndpointType is unset",
+			spec:     hyperspikeiov1.ValkeySpec{TLS: true},
+			expected: "hostname",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			valkey := &hyperspikeiov1.Valkey{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec:       tt.spec,
+			}
+			result := resolveEndpointType(valkey)
+			if result != tt.expected {
+				t.Errorf("resolveEndpointType() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestServicePasswordName(t *testing.T) {
 	valkey := &hyperspikeiov1.Valkey{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
When a valkey pod restarts the valkey cluster keeps announcing the old IP. #199 added an option to prefer `hostname` which likely would counteract this problem but it's seemingly incomplete.  

This is also mentioned by @smadhale in https://github.com/hyperspike/valkey-operator/pull/199#issuecomment-3252185501

This adds code to add `cluster-announce-hostname` on every pod so the cluster topology is stable across pod restarts 
