### PR TITLE
feat(controller): Add standalone (non-cluster) deployment mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,20 @@ This operator creates valkey clusters and makes them available to other services
 
 See the following link for more information on available Custom Resource Options: [https://doc.crds.dev/github.com/hyperspike/valkey-operator](https://doc.crds.dev/github.com/hyperspike/valkey-operator)
 
+### Standalone
+
+A `Valkey` resource is provisioned as a Valkey Cluster by default. To run a single,
+non-clustered server (`cluster-enabled no`) instead, set `standalone`:
+
+```yaml
+apiVersion: hyperspike.io/v1
+kind: Valkey
+metadata:
+  name: valkey
+spec:
+  standalone: true
+```
+
 ## Getting Started
 
 ### Prerequisites

--- a/api/v1/valkey_types.go
+++ b/api/v1/valkey_types.go
@@ -139,6 +139,15 @@ type ValkeySpec struct {
 	// +kubebuilder:default:=false
 	// +optional
 	PlatformManagedSecurityContext bool `json:"platformManagedSecurityContext,omitempty"`
+
+	// Standalone runs a single Valkey server with cluster mode disabled
+	// (cluster-enabled no) rather than a Valkey Cluster. When true the operator
+	// deploys exactly one server and skips the cluster bootstrap (cluster meet,
+	// add-slots, rebalance and cluster-announce-ip). Shards and Replicas are
+	// forced to a single node in this mode.
+	// +kubebuilder:default:=false
+	// +optional
+	Standalone bool `json:"standalone,omitempty"`
 }
 
 // ExternalAccess defines the external access configuration

--- a/config/crd/bases/hyperspike.io_valkeys.yaml
+++ b/config/crd/bases/hyperspike.io_valkeys.yaml
@@ -368,6 +368,15 @@ spec:
                 - key
                 type: object
                 x-kubernetes-map-type: atomic
+              standalone:
+                default: false
+                description: |-
+                  Standalone runs a single Valkey server with cluster mode disabled
+                  (cluster-enabled no) rather than a Valkey Cluster. When true the operator
+                  deploys exactly one server and skips the cluster bootstrap (cluster meet,
+                  add-slots, rebalance and cluster-announce-ip). Shards and Replicas are
+                  forced to a single node in this mode.
+                type: boolean
               storage:
                 description: |-
                   Persistent volume claim. The kind and metadata can be omitted, but the spec
@@ -485,7 +494,7 @@ spec:
                       resources:
                         description: |-
                           resources represents the minimum resources the volume should have.
-                          If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                          Users are allowed to specify resource requirements
                           that are lower than previous value but must still be higher than capacity recorded in the
                           status field of the claim.
                           More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -642,8 +651,7 @@ spec:
                           for the purpose it was designed. For example - a controller
                           that\nonly is responsible for resizing capacity of the volume,
                           should ignore PVC updates that change other valid\nresources
-                          associated with PVC.\n\nThis is an alpha field and requires
-                          enabling RecoverVolumeExpansionFailure feature."
+                          associated with PVC."
                         type: object
                         x-kubernetes-map-type: granular
                       allocatedResources:
@@ -674,8 +682,7 @@ spec:
                           for the purpose it was designed. For example - a controller
                           that\nonly is responsible for resizing capacity of the volume,
                           should ignore PVC updates that change other valid\nresources
-                          associated with PVC.\n\nThis is an alpha field and requires
-                          enabling RecoverVolumeExpansionFailure feature."
+                          associated with PVC."
                         type: object
                       capacity:
                         additionalProperties:
@@ -795,9 +802,10 @@ spec:
                     operator:
                       description: |-
                         Operator represents a key's relationship to the value.
-                        Valid operators are Exists and Equal. Defaults to Equal.
+                        Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                         Exists is equivalent to wildcard for value, so that a pod can
                         tolerate all taints of a particular category.
+                        Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                       type: string
                     tolerationSeconds:
                       description: |-

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,4 +1,5 @@
 ## Append samples of your project ##
 resources:
 - v1_valkey.yaml
+- v1_valkey_standalone.yaml
 # +kubebuilder:scaffold:manifestskustomizesamples

--- a/config/samples/v1_valkey_standalone.yaml
+++ b/config/samples/v1_valkey_standalone.yaml
@@ -1,0 +1,9 @@
+apiVersion: hyperspike.io/v1
+kind: Valkey
+metadata:
+  labels:
+    app.kubernetes.io/name: valkey-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: valkey-standalone-sample
+spec:
+  standalone: true

--- a/internal/controller/scripts/valkey.conf
+++ b/internal/controller/scripts/valkey.conf
@@ -195,7 +195,7 @@ tcp-keepalive 300
 port 0
 tls-auth-clients no
 
-tls-cluster yes
+{{ if not .Spec.Standalone }}tls-cluster yes{{ end }}
 tls-replication yes
 tls-port 6379
 tls-cert-file /etc/valkey/certs/tls.crt
@@ -1569,7 +1569,7 @@ lua-time-limit 5000
 # started as cluster nodes can. In order to start a Valkey instance as a
 # cluster node enable the cluster support uncommenting the following:
 #
-cluster-enabled yes
+cluster-enabled {{ if .Spec.Standalone }}no{{ else }}yes{{ end }}
 
 # Every cluster node has a cluster configuration file. This file is not
 # intended to be edited by hand. It is created and updated by Valkey nodes.
@@ -1577,7 +1577,7 @@ cluster-enabled yes
 # Make sure that instances running in the same system do not have
 # overlapping cluster configuration file names.
 #
-cluster-config-file /data/nodes.conf
+{{ if not .Spec.Standalone }}cluster-config-file /data/nodes.conf{{ end }}
 
 # Cluster node timeout is the amount of milliseconds a node must be unreachable
 # for it to be considered in failure state.
@@ -1746,7 +1746,7 @@ cluster-config-file /data/nodes.conf
 # the client to reach out on the same endpoint it used for making the last request, but use
 # the port provided in the response.
 
-cluster-preferred-endpoint-type {{ .Spec.ClusterPreferredEndpointType }}
+{{ if not .Spec.Standalone }}cluster-preferred-endpoint-type {{ .Spec.ClusterPreferredEndpointType }}{{ end }}
 
 ########################## CLUSTER DOCKER/NAT support  ########################
 

--- a/internal/controller/valkey_controller.go
+++ b/internal/controller/valkey_controller.go
@@ -207,11 +207,22 @@ func (r *ValkeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			return ctrl.Result{}, err
 		}
 	}
-	if err = r.upsertPodDisruptionBudget(ctx, valkey); err != nil {
-		return ctrl.Result{}, err
+	if !valkey.Spec.Standalone {
+		if err = r.upsertPodDisruptionBudget(ctx, valkey); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 	if err = r.upsertStatefulSet(ctx, valkey); err != nil {
 		return ctrl.Result{}, err
+	}
+	if valkey.Spec.Standalone {
+		if err = r.checkState(ctx, valkey); err != nil {
+			return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 3}, nil
+		}
+		if !valkey.Status.Ready {
+			return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5}, nil
+		}
+		return ctrl.Result{}, nil
 	}
 	if err = r.initCluster(ctx, valkey); err != nil {
 		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 3}, err
@@ -237,6 +248,11 @@ func (r *ValkeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 }
 
 func (r *ValkeyReconciler) validateValkeySpec(valkey *hyperv1.Valkey) error {
+	if valkey.Spec.Standalone {
+		valkey.Spec.Shards = 1
+		valkey.Spec.Replicas = 0
+	}
+
 	if valkey.Spec.Shards < 1 {
 		valkey.Spec.Shards = r.GlobalConfig.Nodes
 		if valkey.Spec.Shards < 1 {
@@ -310,7 +326,7 @@ func (r *ValkeyReconciler) checkState(ctx context.Context, valkey *hyperv1.Valke
 
 	initHost := fmt.Sprintf("%s.%s.svc", valkey.Name, valkey.Namespace)
 	initAddress := fmt.Sprintf("%s:%d", initHost, ValkeyPort)
-	vClient, err := r.getClient(ctx, valkey, initAddress, false)
+	vClient, err := r.getClient(ctx, valkey, initAddress, valkey.Spec.Standalone)
 	if err != nil {
 		logger.Error(err, "failed to create valkey client")
 		return err

--- a/internal/controller/valkey_controller_utils_test.go
+++ b/internal/controller/valkey_controller_utils_test.go
@@ -17,9 +17,13 @@ limitations under the License.
 package controller
 
 import (
+	"bytes"
+	"strings"
 	"testing"
+	"text/template"
 
 	hyperspikeiov1 "hyperspike.io/valkey-operator/api/v1"
+	globalcfg "hyperspike.io/valkey-operator/cfg"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -111,5 +115,82 @@ func TestServicePasswordName(t *testing.T) {
 	result = getServicePasswordName(valkey)
 	if result != "test-password" {
 		t.Errorf("Expected %v, got %v", "test-password", result)
+	}
+}
+
+func TestStandaloneConfigRender(t *testing.T) {
+	render := func(standalone bool) string {
+		raw, err := scripts.ReadFile("scripts/valkey.conf")
+		if err != nil {
+			t.Fatalf("failed to read valkey.conf: %v", err)
+		}
+		tmpl, err := template.New("valkey.conf").Parse(string(raw))
+		if err != nil {
+			t.Fatalf("failed to parse valkey.conf: %v", err)
+		}
+		valkey := &hyperspikeiov1.Valkey{
+			Spec: hyperspikeiov1.ValkeySpec{
+				Standalone:                   standalone,
+				ClusterPreferredEndpointType: "ip",
+			},
+		}
+		buf := &bytes.Buffer{}
+		if err := tmpl.Execute(buf, valkey); err != nil {
+			t.Fatalf("failed to render valkey.conf: %v", err)
+		}
+		return buf.String()
+	}
+
+	hasDirective := func(conf, name string) bool {
+		for _, line := range strings.Split(conf, "\n") {
+			if strings.HasPrefix(strings.TrimSpace(line), name+" ") {
+				return true
+			}
+		}
+		return false
+	}
+
+	standalone := render(true)
+	if !strings.Contains(standalone, "cluster-enabled no") {
+		t.Errorf("standalone config should set 'cluster-enabled no'")
+	}
+	if hasDirective(standalone, "cluster-config-file") {
+		t.Errorf("standalone config should not set cluster-config-file")
+	}
+	if hasDirective(standalone, "cluster-preferred-endpoint-type") {
+		t.Errorf("standalone config should not set cluster-preferred-endpoint-type")
+	}
+
+	cluster := render(false)
+	if !strings.Contains(cluster, "cluster-enabled yes") {
+		t.Errorf("cluster config should set 'cluster-enabled yes'")
+	}
+	if !hasDirective(cluster, "cluster-config-file") {
+		t.Errorf("cluster config should set cluster-config-file")
+	}
+}
+
+func TestValidateStandaloneCoercesSingleNode(t *testing.T) {
+	r := &ValkeyReconciler{
+		GlobalConfig: &globalcfg.Config{
+			ValkeyImage:  "valkey",
+			SidecarImage: "sidecar",
+		},
+	}
+	valkey := &hyperspikeiov1.Valkey{
+		Spec: hyperspikeiov1.ValkeySpec{
+			Standalone: true,
+			Shards:     3,
+			Replicas:   2,
+		},
+	}
+	if err := r.validateValkeySpec(valkey); err != nil {
+		t.Fatalf("validateValkeySpec returned error: %v", err)
+	}
+	if valkey.Spec.Shards != 1 {
+		t.Errorf("Expected %v, got %v", 1, valkey.Spec.Shards)
+	}
+	if valkey.Spec.Replicas != 0 {
+		t.Errorf("Expected %v, got %v", 0, valkey.Spec.Replicas)
 	}
 }


### PR DESCRIPTION
Adds a `standalone` option to the Valkey spec so a CR can run a single server with `cluster-enabled no` instead of a Valkey Cluster.

## Background

`valkey.conf` always emitted `cluster-enabled yes`, and `Reconcile` unconditionally ran the cluster bootstrap (cluster meet / add-slots / rebalance / cluster-announce-ip), so there was no way to run a plain single-instance Valkey. Fixes #284.

## How it works

- New `standalone` bool on the spec, defaults to `false`, so existing cluster CRs are unchanged.
- When set, `validateValkeySpec` pins `shards=1`/`replicas=0`, so the StatefulSet keeps its existing `shards * (replicas+1)` math and lands on a single pod.
- `valkey.conf` renders `cluster-enabled no` and the remaining active cluster-only directives (`cluster-config-file`, `cluster-preferred-endpoint-type`, `tls-cluster`) are gated out.
- `Reconcile` skips `initCluster`/`balanceNodes`/`setClusterAnnounceIp` and the PodDisruptionBudget, and brings the resource ready via the existing `checkState` PING using the single-client mode.
- The readiness probe already skips the `CLUSTER INFO` check when there is a single node, so it works unmodified.

## Notes

- I went with a `standalone` bool rather than a `mode: Cluster|Standalone` enum to match the existing boolean toggles in the spec (`tls`, `prometheus`, `serviceMonitor`, ...) and to stay backward compatible by default. Happy to switch to an enum if you'd prefer.
- `cluster-enabled` isn't runtime-mutable, so flipping `standalone` on a live instance needs pod recreation — I've treated it as effectively create-time. Can add a CEL immutability rule if you want that enforced.
- `standalone` + `externalAccess` LoadBalancer is out of scope here; `cluster-announce-ip` is a no-op without a cluster bus.

## Example

```yaml
apiVersion: hyperspike.io/v1
kind: Valkey
metadata:
  name: cache
spec:
  standalone: true
```

## Testing

Added unit tests for the config rendering (both modes) and the single-node coercion. Also deployed the build to a cluster and confirmed a standalone CR comes up with `cluster-enabled no`, a single-replica StatefulSet, no PDB, and reaches `Ready`.
